### PR TITLE
Protect against simple typographical errors

### DIFF
--- a/src/Yangqi/Htmldom/Htmldomnode.php
+++ b/src/Yangqi/Htmldom/Htmldomnode.php
@@ -699,7 +699,7 @@ class Htmldomnode
 			else
 			{
 				$sourceCharset = trim($sourceCharset);
-				$converted_text = iconv($sourceCharset, $targetCharset, $text);
+				$converted_text = iconv($sourceCharset, $targetCharset . '//IGNORE', $text);
 			}
 		}
 


### PR DESCRIPTION
Prior to this change 'ISO-8859-1 ' will present you with an error.

This may cause unintended consequences that I'm not aware of (hopefully not), but it works with 'bad HTML' (this specific typo) for now.
