### PR TITLE
Proper tagging for releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Add the following line to the `require` section of `composer.json`:
 ```json
 {
     "require": {
-        "yangqi/htmldom": "dev-master"
+        "yangqi/htmldom": "1.0.*"
     }
 }
 ```


### PR DESCRIPTION
Could you please create the release 1.0.0 and accept that pull request so we avoid using `dev-master` in our `composer.json` files.
I assume that version is stable enough now.
